### PR TITLE
fix: plugin deactivation cause of missing command in plugin.yml

### DIFF
--- a/metacloud-plugin/src/main/resources/plugin.yml
+++ b/metacloud-plugin/src/main/resources/plugin.yml
@@ -10,3 +10,4 @@ website: https://metacloudservice.eu
 
 commands:
   service:
+  stop:


### PR DESCRIPTION
metacloud-plugin got disabled cause of the missing command in the plugin.yml